### PR TITLE
## Code Improvements  ### Use Result instead of Option In your add_task function, you're returning an Option<Task>. This forces the caller to handle the None case every time they call this function. Instead, I changed the return type to Result<Task, Error>. This way, if something goes wrong, it can return an appropriate error message.  ### Optimized Canister Size By default, Rust produces large WebAssembly modules. To reduce the size of your canister, I compiled it with size and link-time optimizations. This will significantly reduce the size of the compiled WebAssembly module.Code improvements

### DIFF
--- a/src/icp_rust_boilerplate_backend/Cargo.toml
+++ b/src/icp_rust_boilerplate_backend/Cargo.toml
@@ -14,3 +14,7 @@ ic-cdk = "0.11.1"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1.0"
 ic-stable-structures = "0.5.6"
+
+[profile.release]
+    lto = true
+    opt-level = 'z'

--- a/src/icp_rust_boilerplate_backend/src/lib.rs
+++ b/src/icp_rust_boilerplate_backend/src/lib.rs
@@ -68,7 +68,7 @@ fn get_task(id: u64) -> Result<Task, Error> {
 }
 
 #[ic_cdk::update]
-fn add_task(task: TaskPayload) -> Option<Task> {
+fn add_task(task: TaskPayload) -> Result<Task, Error> {
     let id = ID_COUNTER
         .with(|counter| {
             let current_value = *counter.borrow().get();
@@ -84,8 +84,8 @@ fn add_task(task: TaskPayload) -> Option<Task> {
         updated_at: None,
     };
     do_insert(&task);
-    Some(task)
-}
+    Ok(task)
+ }
 
 #[ic_cdk::update]
 fn update_task(id: u64, payload: TaskPayload) -> Result<Task, Error> {


### PR DESCRIPTION
## Code Improvements

### Use Result instead of Option
In your add_task function, you're returning an Option<Task>. This forces the caller to handle the None case every time they call this function. Instead, I changed the return type to Result<Task, Error>. This way, if something goes wrong, it can return an appropriate error message.

### Optimized Canister Size
By default, Rust produces large WebAssembly modules. To reduce the size of your canister, I compiled it with size and link-time optimizations. This will significantly reduce the size of the compiled WebAssembly module.